### PR TITLE
fix: output size should change between models

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -38,7 +38,7 @@ def tensor2label(output, n_label, imtype=np.uint8):
 
 def save_image(image_numpy, image_path):
     image_pil = Image.fromarray(image_numpy)
-    image_pil = image_pil.resize((256,256), Image.ANTIALIAS)
+    # image_pil = image_pil.resize((256,256), Image.ANTIALIAS)
     image_pil.save(image_path)
 
 def mkdirs(paths):


### PR DESCRIPTION
removed a line of code that resized all outputs (both while train and while
inference) to be 256/256.
This commit enables utilizing the full power of the local enhancement model.

Thank you for your research
